### PR TITLE
Support setting calibration offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,19 @@ radically but heading remained essentially constant.
 
 # Contents
 
- 1. [Files and dependencies](./README.md#1-files-and-dependencies)  
- 2. [Getting started](./README.md#2-getting-started)  
- 3. [The BNO055 class](./README.md#3-the-bno055-class)  
-  3.1 [Constructor](./README.md#31-constructor)  
-  3.2 [Read only methods](./README.md#32-read-only-methods) Read data from device.  
-  3.3 [Changing the device configuration](./README.md#33-changing-the-device-configuration)  
-    3.3.1 [Mode setting](./README.md#331-mode-setting) Modify device operating mode.  
-    3.3.2 [Rate and range control](./README.md#332-rate-and-range-control) Further settings.  
-  3.4 [Use in interrupt handlers](./README.md#34-use-in-interrupt-handlers)  
-  3.5 [Other methods](./README.md#35-other-methods)  
- 4. [Calibration](./README.md#4-calibration)  
- 5. [Minimal version](./README.md#5-minimal-version) Minimise RAM usage.  
- 6. [References](./README.md#6-references)  
+ 1. [Files and dependencies](./README.md#1-files-and-dependencies)
+ 2. [Getting started](./README.md#2-getting-started)
+ 3. [The BNO055 class](./README.md#3-the-bno055-class)
+  3.1 [Constructor](./README.md#31-constructor)
+  3.2 [Read only methods](./README.md#32-read-only-methods) Read data from device.
+  3.3 [Changing the device configuration](./README.md#33-changing-the-device-configuration)
+    3.3.1 [Mode setting](./README.md#331-mode-setting) Modify device operating mode.
+    3.3.2 [Rate and range control](./README.md#332-rate-and-range-control) Further settings.
+  3.4 [Use in interrupt handlers](./README.md#34-use-in-interrupt-handlers)
+  3.5 [Other methods](./README.md#35-other-methods)
+ 4. [Calibration](./README.md#4-calibration)
+ 5. [Minimal version](./README.md#5-minimal-version) Minimise RAM usage.
+ 6. [References](./README.md#6-references)
 
 # 1. Files and dependencies
 
@@ -135,7 +135,7 @@ implies a rotation around the Z axis.
 
 Sign values must be 0 (normal) or 1 (inverted). Hence a board rotated around
 the Y axis and mounted upside down would have `sign=(1, 0, 1)` (X and Z axes
-inverted). This is further explained in the 
+inverted). This is further explained in the
 [Device datasheet](https://cdn-learn.adafruit.com/assets/assets/000/036/832/original/BST_BNO055_DS000_14.pdf)
 section 3.4.
 
@@ -157,6 +157,10 @@ Return values (numbers are floats unless stated otherwise):
  * `calibrated()` `True` if all elements of the device are calibrated.
  * `cal_status()` Returns bytearray  `[sys, gyro, accel, mag]`. Each element
  has a value from 0 (uncalibrated) to 3 (fully calibrated).
+ * `sensor_offsets()` Returns the current calibration offsets stored on the device as
+ a `bytearray`.
+ * `set_offsets()` Sets the current calibration offsets of the device. For example,
+ this can be called with the results of `sensor_offsets()` after a reset.
  * `external_crystal()` `True` if using an external crystal.
  * `get_config(sensor)` See [Section 3.3.2](./README.md#332-rate-and-range-control).
 
@@ -246,7 +250,7 @@ method returns the config tuple as it was before any change was made. In
 certain circumstances the chip can return an unknown value. This was observed
 in the case of the initial value from the magnetometer. In such cases the
 result will be `False`. Returning the prior value allows old values to be
-restored, e.g.  
+restored, e.g.
 ```python
 old_config = imu.config(ACC, (2, 250))
 # ...
@@ -269,9 +273,9 @@ if imu.config(ACC) == cfg:
 #### Accelerometer (dev == ACC)
 
 `value` is a 2-tuple comprising `(range, bandwidth)`
-Allowable values:  
-Range: 2, 4, 8, 16 (G).  
-Bandwidth: 8, 16, 31, 62, 125, 250, 500, 1000 (Hz).  
+Allowable values:
+Range: 2, 4, 8, 16 (G).
+Bandwidth: 8, 16, 31, 62, 125, 250, 500, 1000 (Hz).
 The outcome of a change may be shown by means of the `.config(ACC)` method.
 ```python
 from bno055 import *
@@ -286,16 +290,16 @@ if imu.config(ACC) == cfg:
 #### Gyro (dev == GYRO)
 
 `value` is a 2-tuple comprising `(range, bandwidth)`
-Allowable values:  
-Range: 125, 250, 500, 1000, 2000 (dps)  
-Bandwidth: 12, 23, 32, 47, 64, 116, 230, 523 (Hz).  
+Allowable values:
+Range: 125, 250, 500, 1000, 2000 (dps)
+Bandwidth: 12, 23, 32, 47, 64, 116, 230, 523 (Hz).
 The outcome of a change may be shown by means of the `.config(GYRO)` method.
 
 #### Magnetometer (dev == MAG)
 
 `value` is a 1-tuple comprising `(rate,)` being the update rate in Hz.
-Allowable values:  
-Rate: 2, 6, 8, 10, 15, 20, 25, 30 (Hz)  
+Allowable values:
+Rate: 2, 6, 8, 10, 15, 20, 25, 30 (Hz)
 The outcome of a change may be shown by means of the `.config(MAG)` method.
 Note that on first call the prior config may be unknown and the method will
 return `False`. This is a chip behaviour.
@@ -411,6 +415,21 @@ NDOF:
  * The `cal_status()` method can be used to see the calibration status of the
  magnetometer.
 
+
+### Calibration Restoration
+
+Restoring previous calibration offsets after a reset is also supported, via the
+`sensor_offsets()` and `set_offsets()` methods.
+
+After a successful calibration, `sensor_offsets()` can be called to retrieve a
+`bytearray`. This can then, for example, be written to disk for loading after a
+reset of the device.
+
+The corresponding `set_offsets()` method allows for restoring calibration offsets
+stored in said `bytearray`. Please be aware that the magnetometer's calibration
+status will remain as 0, as per the `cal_status()` method, even after restoring
+its offsets.
+
 ###### [Contents](./README.md#contents)
 
 # 5. Minimal Version
@@ -450,6 +469,6 @@ while True:
 
 # 6. References
 
-[Adafruit BNO055 breakout](https://www.adafruit.com/product/2472)  
-[Adafruit CircuitPython driver](https://github.com/adafruit/Adafruit_CircuitPython_BNO055.git).  
+[Adafruit BNO055 breakout](https://www.adafruit.com/product/2472)
+[Adafruit CircuitPython driver](https://github.com/adafruit/Adafruit_CircuitPython_BNO055.git).
 [Device datasheet](https://cdn-learn.adafruit.com/assets/assets/000/036/832/original/BST_BNO055_DS000_14.pdf)

--- a/bno055_base.py
+++ b/bno055_base.py
@@ -135,7 +135,7 @@ class BNO055_BASE:
         # https://learn.adafruit.com/adafruit-bno055-absolute-orientation-sensor/device-calibration
         return min(s[1:]) == 3 and s[0] > 0
 
-    def sensorOffsets(self):
+    def sensor_offsets(self):
         lastMode = self._mode
 
         self.mode(_CONFIG_MODE)
@@ -144,7 +144,7 @@ class BNO055_BASE:
 
         return offsets
 
-    def setOffsets(self, buf):
+    def set_offsets(self, buf):
         lastMode = self._mode
         self.mode(_CONFIG_MODE)
 

--- a/bno055_base.py
+++ b/bno055_base.py
@@ -50,6 +50,32 @@ _TRIGGER_REGISTER = const(0x3f)
 _POWER_REGISTER = const(0x3e)
 _ID_REGISTER = const(0x00)
 
+ACCEL_OFFSET_X_LSB_ADDR = const(0x55)
+ACCEL_OFFSET_X_MSB_ADDR = const(0x56)
+ACCEL_OFFSET_Y_LSB_ADDR = const(0x57)
+ACCEL_OFFSET_Y_MSB_ADDR = const(0x58)
+ACCEL_OFFSET_Z_LSB_ADDR = const(0x59)
+ACCEL_OFFSET_Z_MSB_ADDR = const(0x5A)
+
+MAG_OFFSET_X_LSB_ADDR = const(0x5B)
+MAG_OFFSET_X_MSB_ADDR = const(0x5C)
+MAG_OFFSET_Y_LSB_ADDR = const(0x5D)
+MAG_OFFSET_Y_MSB_ADDR = const(0x5E)
+MAG_OFFSET_Z_LSB_ADDR = const(0x5F)
+MAG_OFFSET_Z_MSB_ADDR = const(0x60)
+
+GYRO_OFFSET_X_LSB_ADDR = const(0x61)
+GYRO_OFFSET_X_MSB_ADDR = const(0x62)
+GYRO_OFFSET_Y_LSB_ADDR = const(0x63)
+GYRO_OFFSET_Y_MSB_ADDR = const(0x64)
+GYRO_OFFSET_Z_LSB_ADDR = const(0x65)
+GYRO_OFFSET_Z_MSB_ADDR = const(0x66)
+
+ACCEL_RADIUS_LSB_ADDR = const(0x67)
+ACCEL_RADIUS_MSB_ADDR = const(0x68)
+MAG_RADIUS_LSB_ADDR = const(0x69)
+MAG_RADIUS_MSB_ADDR = const(0x6A)
+
 class BNO055_BASE:
 
     def __init__(self, i2c, address=0x28, crystal=True, transpose=(0, 1, 2), sign=(0, 0, 0)):
@@ -63,6 +89,7 @@ class BNO055_BASE:
         self.gyro = lambda : self.scaled_tuple(0x14, 1/16)  # deg.s^-1
         self.euler = lambda : self.scaled_tuple(0x1a, 1/16)  # degrees (heading, roll, pitch)
         self.quaternion = lambda : self.scaled_tuple(0x20, 1/(1<<14), bytearray(8), '<hhhh')  # (w, x, y, z)
+        self._mode = _CONFIG_MODE
         try:
             chip_id = self._read(_ID_REGISTER)
         except OSError:
@@ -108,6 +135,56 @@ class BNO055_BASE:
         # https://learn.adafruit.com/adafruit-bno055-absolute-orientation-sensor/device-calibration
         return min(s[1:]) == 3 and s[0] > 0
 
+    def sensorOffsets(self):
+        lastMode = self._mode
+
+        self.mode(_CONFIG_MODE)
+        offsets = self._readn(bytearray(22), ACCEL_OFFSET_X_LSB_ADDR)
+        self.mode(lastMode)
+
+        return offsets
+
+    def setOffsets(self, buf):
+        lastMode = self._mode
+        self.mode(_CONFIG_MODE)
+
+        time.sleep_ms(25)
+
+        '''Note: Configuration will take place only when user writes to the last
+            byte of each config data pair (ex. ACCEL_OFFSET_Z_MSB_ADDR, etc.).
+            Therefore the last byte must be written whenever the user wants to
+            changes the configuration.'''
+
+        self._write(ACCEL_OFFSET_X_LSB_ADDR, buf[0])
+        self._write(ACCEL_OFFSET_X_MSB_ADDR, buf[1])
+        self._write(ACCEL_OFFSET_Y_LSB_ADDR, buf[2])
+        self._write(ACCEL_OFFSET_Y_MSB_ADDR, buf[3])
+        self._write(ACCEL_OFFSET_Z_LSB_ADDR, buf[4])
+        self._write(ACCEL_OFFSET_Z_MSB_ADDR, buf[5])
+
+        self._write(MAG_OFFSET_X_LSB_ADDR, buf[6])
+        self._write(MAG_OFFSET_X_MSB_ADDR, buf[7])
+        self._write(MAG_OFFSET_Y_LSB_ADDR, buf[8])
+        self._write(MAG_OFFSET_Y_MSB_ADDR, buf[9])
+        self._write(MAG_OFFSET_Z_LSB_ADDR, buf[10])
+        self._write(MAG_OFFSET_Z_MSB_ADDR, buf[11])
+
+        self._write(GYRO_OFFSET_X_LSB_ADDR, buf[12])
+        self._write(GYRO_OFFSET_X_MSB_ADDR, buf[13])
+        self._write(GYRO_OFFSET_Y_LSB_ADDR, buf[14])
+        self._write(GYRO_OFFSET_Y_MSB_ADDR, buf[15])
+        self._write(GYRO_OFFSET_Z_LSB_ADDR, buf[16])
+        self._write(GYRO_OFFSET_Z_MSB_ADDR, buf[17])
+
+        self._write(ACCEL_RADIUS_LSB_ADDR, buf[18])
+        self._write(ACCEL_RADIUS_MSB_ADDR, buf[19])
+
+        self._write(MAG_RADIUS_LSB_ADDR, buf[20])
+        self._write(MAG_RADIUS_MSB_ADDR, buf[21])
+
+        self.mode(lastMode)
+
+
     # read byte from register, return int
     def _read(self, memaddr, buf=bytearray(1)):  # memaddr = memory location within the I2C device
         self._i2c.readfrom_mem_into(self.address, memaddr, buf)
@@ -131,6 +208,8 @@ class BNO055_BASE:
             if new_mode != _CONFIG_MODE:
                 self._write(_MODE_REGISTER, new_mode)
                 time.sleep_ms(10)  # Table 3.6
+
+        self._mode = new_mode
         return old_mode
 
     def external_crystal(self):


### PR DESCRIPTION
This PR adds support for reading (and subsequently re-writing) the current calibration offsets on the BNO055.

I've derived this code from the same approach used in:
- https://github.com/adafruit/Adafruit_BNO055/blob/1b8b604b2099faf1a35737eeccb1cfbad42fdf2b/Adafruit_BNO055.cpp#L583
- https://github.com/adafruit/Adafruit_BNO055/blob/1b8b604b2099faf1a35737eeccb1cfbad42fdf2b/Adafruit_BNO055.cpp#L602